### PR TITLE
feat: create geodatatalk-cli for geospatial data queries

### DIFF
--- a/GEODATATALK-LICENSE
+++ b/GEODATATALK-LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Andrea Borruso
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/GEODATATALK-README.md
+++ b/GEODATATALK-README.md
@@ -1,0 +1,400 @@
+# GeoDataTalk CLI
+
+[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![GDAL](https://img.shields.io/badge/GDAL-3.0+-green.svg)](https://gdal.org/)
+
+## Chat with your geospatial data in plain English. Right from your terminal.
+
+> A **natural language interface** for your **vector** and **raster** geospatial data. Powered by **GDAL/OGR** and **LLMs**. **Fast**, **local**, and **private**.
+
+Skip complex GIS software and command-line syntax. Just ask **"How many buildings are in this dataset?"** or **"What's the elevation range?"**<br>
+Get instant answers from your **local geospatial files**.
+
+**Privacy First:** Your data never leaves your machine. Only schema/metadata is sent to LLM.
+**Formats:** Shapefile, GeoJSON, GeoPackage, KML, GeoTIFF, and 80+ more via GDAL/OGR
+**Performance:** Direct GDAL/OGR access for **instant results**.
+
+**⭐ If you find this useful, please star the repo. It helps a lot!**
+
+## Why GeoDataTalk?
+
+**The Problem:** You have a geospatial file and a simple question. What do you do?
+- Open QGIS? Slow startup, and you have to leave the terminal
+- Use ogr2ogr or gdalinfo? Complex syntax and flags to remember
+- Write Python with GeoPandas? Overkill for "how many features in this shapefile?"
+
+**The Solution:** Just ask your question naturally.
+
+```bash
+gdtalk roads.shp
+> How many road features are there?
+> Show me the 5 longest roads
+> What is the total length of all roads?
+
+gdtalk elevation.tif
+> What is the elevation range?
+> What is the pixel size?
+> What is the value at coordinates 12.5, 41.9?
+```
+
+## Features
+
+- **Natural Language** - Ask questions in plain English, no complex GIS tools required
+- **Interactive Mode** - Ask multiple questions without restarting the command
+- **100% Local Processing** - Data never leaves your machine, only schema/metadata is sent to LLM
+- **100% Offline Option** - Use local Ollama models for complete offline operation
+- **Fast** - Direct GDAL/OGR access processes data instantly
+- **Vector & Raster Support** - Query both vector features and raster pixels
+- **100+ LLM Models** - Powered by [LiteLLM](https://docs.litellm.ai) - OpenAI, Anthropic, Google, Ollama (local), and more
+- **80+ Geospatial Formats** - Supports all GDAL/OGR formats: Shapefile, GeoJSON, GeoPackage, KML, GeoTIFF, and more
+- **Scriptable** - JSON output format for automation and pipelines
+- **Simple Configuration** - Just set `LLM_MODEL` and API key environment variables
+- **Transparent** - Use `--operation` to see generated operations
+
+## Installation
+
+```bash
+pip install geodatatalk-cli
+```
+
+**Requirements:**
+- Python 3.9+
+- GDAL 3.0+ (system installation)
+- Either an API key for cloud models (OpenAI, Anthropic, etc.) OR local Ollama for offline use
+
+### Installing GDAL
+
+**Ubuntu/Debian:**
+```bash
+sudo apt-get install gdal-bin libgdal-dev
+export CPLUS_INCLUDE_PATH=/usr/include/gdal
+export C_INCLUDE_PATH=/usr/include/gdal
+```
+
+**macOS:**
+```bash
+brew install gdal
+```
+
+**Windows:**
+Download from https://gdal.org/ or use OSGeo4W
+
+## Quick Start
+
+```bash
+# Option 1: Use cloud models (OpenAI, Anthropic, Google, etc.)
+export LLM_MODEL="gpt-4o"
+export OPENAI_API_KEY="your-key-here"
+
+# Option 2: Use local Ollama (100% offline, fully private, no API key needed!)
+export LLM_MODEL="ollama/llama3.1"
+# No API key needed - works completely offline!
+
+# Start interactive mode - ask multiple questions about vector data
+gdtalk roads.shp
+
+# You'll get a prompt where you can ask questions naturally:
+# > How many roads are there?
+# > Show me roads with length > 1000
+# > What is the average road length?
+
+# Or analyze raster data
+gdtalk elevation.tif
+# > What is the elevation range?
+# > What's the value at coordinates 12.5, 41.9?
+# > Show me band statistics
+
+# Or use single query mode for quick answers
+gdtalk buildings.geojson -p "How many buildings are there?"
+gdtalk parcels.shp -p "Show me the 10 largest parcels"
+```
+
+## Configuration
+
+GeoDataTalk uses [LiteLLM](https://docs.litellm.ai) to support 100+ models from various providers through a unified interface.
+
+### Required Environment Variables
+
+Set two environment variables:
+
+```bash
+# 1. Choose your model
+export LLM_MODEL="gpt-4o"
+
+# 2. Set the API key for your provider
+export OPENAI_API_KEY="your-key"
+```
+
+### Supported Models
+
+**OpenAI:**
+```bash
+export LLM_MODEL="gpt-4o"  # or gpt-4o-mini, gpt-3.5-turbo
+export OPENAI_API_KEY="sk-..."
+```
+
+**Anthropic Claude:**
+```bash
+export LLM_MODEL="claude-3-5-sonnet-20241022"
+export ANTHROPIC_API_KEY="sk-ant-..."
+```
+
+**Google Gemini:**
+```bash
+export LLM_MODEL="gemini-1.5-flash"  # or gemini-1.5-pro
+export GEMINI_API_KEY="..."
+```
+
+**Ollama (100% Offline - fully private, no internet required!):**
+```bash
+# Install Ollama from https://ollama.ai
+# Start Ollama: ollama serve
+# Pull a model: ollama pull llama3.1
+
+export LLM_MODEL="ollama/llama3.1"  # or ollama/mistral, ollama/codellama
+# No API key needed! Works completely offline.
+```
+
+**Azure OpenAI:**
+```bash
+export LLM_MODEL="azure/gpt-4o"  # Use your deployment name
+export AZURE_API_KEY="..."
+export AZURE_API_BASE="https://your-resource.openai.azure.com"
+export AZURE_API_VERSION="2024-02-01"
+```
+
+**And 100+ more models!** See [LiteLLM Providers](https://docs.litellm.ai/docs/providers) for the complete list.
+
+### Optional Configuration
+
+**MODEL_TEMPERATURE** - Control LLM response randomness (default: 0.1)
+```bash
+export MODEL_TEMPERATURE="0.5"  # Range: 0.0-2.0. Lower = more deterministic, Higher = more creative
+```
+
+### Using .env file
+
+Create a `.env` file in your project directory:
+
+```bash
+LLM_MODEL=gpt-4o
+OPENAI_API_KEY=your-key
+```
+
+## Usage
+
+**Interactive mode** - ask multiple questions:
+```bash
+gdtalk roads.shp
+gdtalk elevation.tif
+```
+
+**Direct query** - single question and exit:
+```bash
+gdtalk buildings.geojson -p "How many buildings?"
+# or using long form:
+gdtalk parcels.shp --prompt "Show me parcels larger than 1000 sqm"
+```
+
+### Vector Data Examples
+
+```bash
+# Feature counts
+gdtalk buildings.geojson -p "How many buildings?"
+gdtalk roads.shp -p "Count the road features"
+
+# Filtering & listing
+gdtalk roads.shp -p "Show me roads with NAME like 'Main%'"
+gdtalk buildings.geojson -p "List buildings with height > 50"
+
+# Statistics
+gdtalk parcels.shp -p "What is the average area?"
+gdtalk roads.shp -p "Show statistics for the LENGTH field"
+
+# Spatial queries
+gdtalk points.geojson -p "Show features within bbox -122.5, 37.7, -122.3, 37.8"
+
+# Supported vector formats:
+# - Shapefile (.shp)
+# - GeoJSON (.geojson, .json)
+# - GeoPackage (.gpkg)
+# - KML/KMZ (.kml, .kmz)
+# - GML (.gml)
+# - And many more...
+```
+
+### Raster Data Examples
+
+```bash
+# Dataset information
+gdtalk elevation.tif -p "Describe this raster"
+gdtalk landsat.tif -p "How many bands?"
+
+# Statistics
+gdtalk elevation.tif -p "What is the elevation range?"
+gdtalk temperature.tif -p "Show band 1 statistics"
+
+# Pixel values
+gdtalk elevation.tif -p "What's the value at coordinates 12.5, 41.9?"
+gdtalk landsat.tif -p "Get pixel value at 500000, 4500000 for band 3"
+
+# Supported raster formats:
+# - GeoTIFF (.tif, .tiff)
+# - NetCDF (.nc)
+# - HDF (.hdf, .h5)
+# - ERDAS Imagine (.img)
+# - And many more...
+```
+
+## Options
+
+### Query Modes
+
+```bash
+# Interactive mode (default) - ask multiple questions
+gdtalk roads.shp
+
+# Non-interactive mode - single query and exit
+gdtalk roads.shp -p "How many roads?"
+gdtalk roads.shp --prompt "Show me the 5 longest roads"
+```
+
+### Output Formats (with `-p` only)
+
+GeoDataTalk supports multiple output formats:
+
+```bash
+# Human-readable table (default)
+gdtalk roads.shp -p "Show me 5 roads"
+
+# JSON format - for scripting and automation
+gdtalk roads.shp -p "Count roads" --json
+# Output: {"operation": {...}, "result": {...}, "error": null}
+```
+
+### Debug & Display Options
+
+```bash
+# Show generated operation details along with results
+gdtalk roads.shp -p "query" --operation
+
+# Hide field/band details table when loading data
+gdtalk roads.shp --no-schema
+
+# Combine options
+gdtalk roads.shp -p "query" --operation --no-schema
+```
+
+### Scripting
+
+GeoDataTalk supports structured output formats for integration with scripts and pipelines:
+
+```bash
+# JSON output for scripting
+COUNT=$(gdtalk roads.shp -p "count roads" --json | jq -r '.result.count')
+echo "Total Roads: $COUNT"
+
+# Process multiple files
+for file in *.shp; do
+  COUNT=$(gdtalk "$file" -p "count features" --json | jq -r '.result.count')
+  echo "$file: $COUNT features"
+done
+
+# Check raster statistics
+MIN=$(gdtalk elevation.tif -p "band 1 min value" --json | jq -r '.result.data.min')
+MAX=$(gdtalk elevation.tif -p "band 1 max value" --json | jq -r '.result.data.max')
+echo "Elevation range: $MIN to $MAX"
+
+# Combine with other geospatial tools
+gdtalk input.shp -p "features with area > 1000" --json | \
+  jq '.result.features[]' | \
+  ogr2ogr -f GeoJSON output.geojson /vsistdin/
+```
+
+## Supported Geospatial Formats
+
+GeoDataTalk supports all formats that GDAL/OGR can read:
+
+**Vector formats (80+):**
+- Shapefile, GeoJSON, GeoPackage, KML/KMZ, GML, CSV with geometries
+- PostGIS, SpatiaLite, Oracle Spatial, MySQL Spatial
+- DXF, DWG, DGN, MapInfo, OpenStreetMap PBF
+- And many more...
+
+**Raster formats (140+):**
+- GeoTIFF, NetCDF, HDF4/HDF5, ERDAS Imagine
+- JPEG, PNG, BMP (with world files)
+- GRIB, NITF, MrSID, ECW
+- And many more...
+
+See the full list at https://gdal.org/drivers/
+
+## Exit Codes
+
+GeoDataTalk returns standard exit codes for use in scripts and automation:
+
+| Exit Code | Meaning | Example |
+|-----------|---------|---------|
+| `0` | Success | Query completed successfully |
+| `1` | Runtime error | Missing API key, query failed, file not found |
+| `2` | Invalid arguments | `--json` without `-p`, invalid option combination |
+
+**Example usage in scripts:**
+```bash
+if gdtalk roads.shp -p "count roads" --json > result.json; then
+    echo "Success!"
+else
+    echo "Failed with exit code $?"
+fi
+```
+
+## FAQ
+
+**Q: Can I use this completely offline?**
+A: Yes! Use local Ollama models and GeoDataTalk works 100% offline with no internet connection required. Your data and queries never leave your machine.
+
+**Q: Is my geospatial data sent to the LLM provider?**
+A: With cloud models, only schema/metadata (field names, types, projection info) is sent - your actual feature data stays local. With local Ollama models, nothing leaves your machine at all.
+
+**Q: What geospatial formats are supported?**
+A: All formats supported by GDAL/OGR - 80+ vector formats (Shapefile, GeoJSON, GeoPackage, etc.) and 140+ raster formats (GeoTIFF, NetCDF, HDF, etc.).
+
+**Q: How large datasets can I query?**
+A: GDAL/OGR can handle very large files efficiently. For huge datasets, filtering and limiting results is recommended for performance.
+
+**Q: Does this replace QGIS or ArcGIS?**
+A: No, GeoDataTalk is designed for quick data exploration and simple queries from the command line. For complex spatial analysis and visualization, traditional GIS software is still recommended.
+
+**Q: Can I do spatial operations like buffers, intersections, etc?**
+A: Currently, GeoDataTalk focuses on data exploration (querying, filtering, statistics). Complex spatial operations are best done with dedicated GIS tools or libraries.
+
+## Architecture
+
+GeoDataTalk is built on top of:
+- **GDAL/OGR** - Industry-standard geospatial data abstraction library
+- **LiteLLM** - Unified interface to 100+ LLM providers
+- **Rich** - Beautiful terminal output
+
+The architecture is similar to DataTalk CLI but adapted for geospatial data:
+1. Load geospatial data using GDAL/OGR
+2. Extract schema/metadata (fields, projection, extent, etc.)
+3. Use LLM to convert natural language to structured geospatial operations
+4. Execute operations using GDAL/OGR APIs
+5. Display results in human-readable format
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues or pull requests.
+
+## License
+
+MIT License - see LICENSE file.
+
+Built with [GDAL/OGR](https://gdal.org/), [LiteLLM](https://docs.litellm.ai), and [Rich](https://rich.readthedocs.io/).
+
+## Related Projects
+
+- [DataTalk CLI](https://github.com/vtsaplin/datatalk-cli) - Natural language interface for CSV, Excel, and Parquet files
+- [GDAL](https://gdal.org/) - Geospatial Data Abstraction Library
+- [OGR](https://gdal.org/programs/ogr2ogr.html) - Vector data conversion utility

--- a/geodatatalk-pyproject.toml
+++ b/geodatatalk-pyproject.toml
@@ -1,0 +1,41 @@
+[project]
+name = "geodatatalk-cli"
+version = "0.1.0"
+description = "Ask questions about your geospatial data (vector & raster) in natural language using GDAL/OGR."
+readme = "GEODATATALK-README.md"
+license = {text = "MIT"}
+requires-python = ">=3.9"
+authors = [
+    {name = "Andrea Borruso", email = "aborruso@example.com"},
+]
+dependencies = [
+    "gdal>=3.0.0",
+    "python-dotenv>=1.0.0",
+    "litellm>=1.0.0",
+    "rich>=13.0.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/aborruso/geodatatalk-cli"
+Repository = "https://github.com/aborruso/geodatatalk-cli"
+Issues = "https://github.com/aborruso/geodatatalk-cli/issues"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0.0",
+]
+
+[project.scripts]
+gdtalk = "geodatatalk.main:main"
+
+[tool.uv]
+dev-dependencies = [
+    "pytest>=7.0.0",
+]
+
+[tool.setuptools.packages.find]
+include = ["geodatatalk*"]
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/geodatatalk/__init__.py
+++ b/geodatatalk/__init__.py
@@ -1,0 +1,3 @@
+"""GeoDataTalk CLI - Natural language interface for geospatial data files."""
+
+__version__ = "0.1.0"

--- a/geodatatalk/geodatabase.py
+++ b/geodatatalk/geodatabase.py
@@ -1,0 +1,279 @@
+"""Geospatial database operations with GDAL/OGR."""
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+import json
+
+try:
+    from osgeo import gdal, ogr, osr
+except ImportError:
+    import gdal
+    import ogr
+    import osr
+
+# Enable GDAL exceptions
+gdal.UseExceptions()
+
+
+class GeoDataSource:
+    """Wrapper for geospatial data sources (vector or raster)."""
+
+    def __init__(self, path: str):
+        self.path = path
+        self.file_path = Path(path)
+        self.data_type = None  # 'vector' or 'raster'
+        self.dataset = None
+        self._load_dataset()
+
+    def _load_dataset(self) -> None:
+        """Load the geospatial dataset and determine its type."""
+        # Try opening as vector first
+        vector_ds = ogr.Open(self.path)
+        if vector_ds is not None:
+            self.data_type = 'vector'
+            self.dataset = vector_ds
+            return
+
+        # Try opening as raster
+        raster_ds = gdal.Open(self.path)
+        if raster_ds is not None:
+            self.data_type = 'raster'
+            self.dataset = raster_ds
+            return
+
+        raise ValueError(f"Could not open {self.path} as vector or raster data")
+
+    def get_info(self) -> Dict[str, Any]:
+        """Get comprehensive information about the dataset."""
+        if self.data_type == 'vector':
+            return self._get_vector_info()
+        else:
+            return self._get_raster_info()
+
+    def _get_vector_info(self) -> Dict[str, Any]:
+        """Get information about vector data."""
+        layer = self.dataset.GetLayer(0)
+        layer_defn = layer.GetLayerDefn()
+
+        # Get geometry type
+        geom_type = ogr.GeometryTypeToName(layer.GetGeomType())
+
+        # Get spatial reference
+        srs = layer.GetSpatialRef()
+        proj_name = srs.GetAttrValue('PROJCS') if srs else 'Unknown'
+        if not proj_name:
+            proj_name = srs.GetAttrValue('GEOGCS') if srs else 'Unknown'
+        epsg_code = srs.GetAttrValue('AUTHORITY', 1) if srs else None
+
+        # Get extent
+        extent = layer.GetExtent()
+
+        # Get feature count
+        feature_count = layer.GetFeatureCount()
+
+        # Get field information
+        fields = []
+        for i in range(layer_defn.GetFieldCount()):
+            field_defn = layer_defn.GetFieldDefn(i)
+            field_type = field_defn.GetFieldTypeName(field_defn.GetType())
+
+            # Get sample values
+            samples = []
+            layer.ResetReading()
+            for feature in layer:
+                value = feature.GetField(i)
+                if value is not None and value not in samples:
+                    samples.append(value)
+                if len(samples) >= 3:
+                    break
+
+            fields.append({
+                'name': field_defn.GetName(),
+                'type': field_type,
+                'samples': samples
+            })
+
+        layer.ResetReading()
+
+        return {
+            'data_type': 'vector',
+            'geometry_type': geom_type,
+            'feature_count': feature_count,
+            'fields': fields,
+            'projection': proj_name,
+            'epsg': epsg_code,
+            'extent': {
+                'min_x': extent[0],
+                'max_x': extent[1],
+                'min_y': extent[2],
+                'max_y': extent[3]
+            }
+        }
+
+    def _get_raster_info(self) -> Dict[str, Any]:
+        """Get information about raster data."""
+        # Get raster dimensions
+        width = self.dataset.RasterXSize
+        height = self.dataset.RasterYSize
+        band_count = self.dataset.RasterCount
+
+        # Get geotransform
+        geotransform = self.dataset.GetGeoTransform()
+
+        # Get projection
+        projection = self.dataset.GetProjection()
+        srs = osr.SpatialReference(wkt=projection)
+        proj_name = srs.GetAttrValue('PROJCS') if srs else 'Unknown'
+        if not proj_name:
+            proj_name = srs.GetAttrValue('GEOGCS') if srs else 'Unknown'
+        epsg_code = srs.GetAttrValue('AUTHORITY', 1) if srs else None
+
+        # Get bands information
+        bands = []
+        for i in range(1, band_count + 1):
+            band = self.dataset.GetRasterBand(i)
+            band_info = {
+                'number': i,
+                'data_type': gdal.GetDataTypeName(band.DataType),
+                'color_interpretation': gdal.GetColorInterpretationName(band.GetColorInterpretation()),
+                'min': band.GetMinimum(),
+                'max': band.GetMaximum(),
+                'nodata': band.GetNoDataValue()
+            }
+
+            # Calculate statistics if not available
+            if band_info['min'] is None or band_info['max'] is None:
+                stats = band.ComputeStatistics(False)
+                band_info['min'] = stats[0]
+                band_info['max'] = stats[1]
+                band_info['mean'] = stats[2]
+                band_info['stddev'] = stats[3]
+
+            bands.append(band_info)
+
+        # Calculate extent
+        min_x = geotransform[0]
+        max_y = geotransform[3]
+        max_x = min_x + geotransform[1] * width
+        min_y = max_y + geotransform[5] * height
+
+        return {
+            'data_type': 'raster',
+            'width': width,
+            'height': height,
+            'band_count': band_count,
+            'bands': bands,
+            'projection': proj_name,
+            'epsg': epsg_code,
+            'pixel_size': {
+                'x': geotransform[1],
+                'y': abs(geotransform[5])
+            },
+            'extent': {
+                'min_x': min_x,
+                'max_x': max_x,
+                'min_y': min_y,
+                'max_y': max_y
+            }
+        }
+
+    def query_features(self, sql: Optional[str] = None,
+                      bbox: Optional[Tuple[float, float, float, float]] = None,
+                      limit: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Query vector features with optional SQL, bounding box, or limit."""
+        if self.data_type != 'vector':
+            raise ValueError("Query features only works with vector data")
+
+        layer = self.dataset.GetLayer(0)
+
+        # Apply spatial filter if bbox provided
+        if bbox:
+            layer.SetSpatialFilterRect(*bbox)
+
+        # Apply SQL filter if provided
+        if sql:
+            result_layer = self.dataset.ExecuteSQL(sql)
+            if result_layer:
+                layer = result_layer
+
+        # Collect features
+        features = []
+        layer.ResetReading()
+        count = 0
+
+        for feature in layer:
+            if limit and count >= limit:
+                break
+
+            # Get feature attributes
+            feature_dict = {'id': feature.GetFID()}
+
+            # Get geometry
+            geom = feature.GetGeometryRef()
+            if geom:
+                feature_dict['geometry_type'] = geom.GetGeometryName()
+                feature_dict['geometry'] = geom.ExportToJson()
+
+            # Get attributes
+            for i in range(feature.GetFieldCount()):
+                field_name = feature.GetFieldDefnRef(i).GetName()
+                feature_dict[field_name] = feature.GetField(i)
+
+            features.append(feature_dict)
+            count += 1
+
+        # Clean up SQL result layer
+        if sql and result_layer:
+            self.dataset.ReleaseResultSet(result_layer)
+
+        layer.ResetReading()
+        return features
+
+    def get_band_statistics(self, band_number: int = 1) -> Dict[str, float]:
+        """Get statistics for a raster band."""
+        if self.data_type != 'raster':
+            raise ValueError("Band statistics only work with raster data")
+
+        band = self.dataset.GetRasterBand(band_number)
+        stats = band.ComputeStatistics(False)
+
+        return {
+            'min': stats[0],
+            'max': stats[1],
+            'mean': stats[2],
+            'stddev': stats[3]
+        }
+
+    def get_pixel_value(self, x: float, y: float, band_number: int = 1) -> Optional[float]:
+        """Get pixel value at geographic coordinates."""
+        if self.data_type != 'raster':
+            raise ValueError("Pixel values only work with raster data")
+
+        # Convert geographic coordinates to pixel coordinates
+        geotransform = self.dataset.GetGeoTransform()
+        inv_geotransform = gdal.InvGeoTransform(geotransform)
+
+        pixel_x = int(inv_geotransform[0] + inv_geotransform[1] * x + inv_geotransform[2] * y)
+        pixel_y = int(inv_geotransform[3] + inv_geotransform[4] * x + inv_geotransform[5] * y)
+
+        # Check if within bounds
+        if pixel_x < 0 or pixel_x >= self.dataset.RasterXSize or \
+           pixel_y < 0 or pixel_y >= self.dataset.RasterYSize:
+            return None
+
+        # Read pixel value
+        band = self.dataset.GetRasterBand(band_number)
+        value = band.ReadAsArray(pixel_x, pixel_y, 1, 1)
+
+        return float(value[0, 0]) if value is not None else None
+
+    def close(self) -> None:
+        """Close the dataset."""
+        if self.dataset:
+            self.dataset = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/geodatatalk/geollm.py
+++ b/geodatatalk/geollm.py
@@ -1,0 +1,201 @@
+"""LLM provider for geospatial query generation using LiteLLM."""
+
+import os
+import re
+import json
+import litellm
+
+# Suppress litellm debug messages
+litellm.suppress_debug_info = True
+
+
+class GeoLLMProvider:
+    """LLM provider for converting natural language to geospatial queries."""
+
+    def __init__(self, model: str):
+        self.model = model
+
+    def to_geo_operation(self, question: str, data_info: dict) -> dict:
+        """Convert natural language question to geospatial operation."""
+        data_type = data_info.get('data_type', 'unknown')
+
+        if data_type == 'vector':
+            return self._to_vector_operation(question, data_info)
+        elif data_type == 'raster':
+            return self._to_raster_operation(question, data_info)
+        else:
+            raise ValueError(f"Unknown data type: {data_type}")
+
+    def _to_vector_operation(self, question: str, data_info: dict) -> dict:
+        """Convert question to vector data operation."""
+        # Prepare schema information
+        fields_info = []
+        for field in data_info.get('fields', []):
+            samples_str = ', '.join([str(s) for s in field['samples'][:3]])
+            fields_info.append(f"{field['name']} ({field['type']}) - samples: {samples_str}")
+
+        schema_str = '\n'.join(fields_info)
+
+        prompt = f"""You are a geospatial analyst assistant. Convert the user's question into a structured operation for vector geospatial data.
+
+Dataset Information:
+- Type: Vector ({data_info.get('geometry_type', 'Unknown')} geometry)
+- Feature Count: {data_info.get('feature_count', 0):,}
+- Projection: {data_info.get('projection', 'Unknown')} (EPSG:{data_info.get('epsg', 'Unknown')})
+- Extent: {data_info.get('extent', {{}})}
+- Fields:
+{schema_str}
+
+Your task is to analyze the question and return a JSON object with the operation details.
+
+Available operations:
+1. "list_features" - List features with optional filters
+2. "count_features" - Count features
+3. "filter_features" - Filter features by attributes
+4. "spatial_filter" - Filter by bounding box
+5. "statistics" - Calculate statistics on a field
+6. "describe" - Describe the dataset
+
+Return JSON in this format:
+{{
+  "operation": "operation_name",
+  "sql": "OGR SQL query if needed (optional)",
+  "limit": number (optional, default 10 for list operations),
+  "field": "field_name for statistics (optional)",
+  "bbox": [min_x, min_y, max_x, max_y] (optional, for spatial filter)
+}}
+
+CRITICAL RULES:
+- Output ONLY valid JSON, nothing else
+- No explanations, no markdown, no code blocks
+- If unsure, use "describe" operation
+- SQL should be valid OGR SQL syntax
+- Use proper field names from the schema above
+
+User question: {question}
+
+JSON response:"""
+
+        try:
+            response = litellm.completion(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=float(os.getenv("MODEL_TEMPERATURE", "0.1")),
+                max_tokens=500,
+            )
+        except Exception as e:
+            cleaned_message = self._clean_litellm_error(str(e))
+            raise ValueError(cleaned_message) from None
+
+        content = response.choices[0].message.content
+        if content is None:
+            raise ValueError(f"No content returned from {self.model}")
+
+        return self._parse_json_response(content)
+
+    def _to_raster_operation(self, question: str, data_info: dict) -> dict:
+        """Convert question to raster data operation."""
+        # Prepare bands information
+        bands_info = []
+        for band in data_info.get('bands', []):
+            bands_info.append(
+                f"Band {band['number']}: {band['data_type']}, "
+                f"range: {band.get('min', 'N/A')} to {band.get('max', 'N/A')}, "
+                f"interpretation: {band.get('color_interpretation', 'Unknown')}"
+            )
+
+        bands_str = '\n'.join(bands_info)
+
+        prompt = f"""You are a geospatial analyst assistant. Convert the user's question into a structured operation for raster geospatial data.
+
+Dataset Information:
+- Type: Raster
+- Dimensions: {data_info.get('width', 0)} x {data_info.get('height', 0)} pixels
+- Bands: {data_info.get('band_count', 0)}
+- Projection: {data_info.get('projection', 'Unknown')} (EPSG:{data_info.get('epsg', 'Unknown')})
+- Pixel Size: {data_info.get('pixel_size', {{}}).get('x', 'N/A')} x {data_info.get('pixel_size', {{}}).get('y', 'N/A')}
+- Extent: {data_info.get('extent', {{}})}
+- Bands Details:
+{bands_str}
+
+Your task is to analyze the question and return a JSON object with the operation details.
+
+Available operations:
+1. "band_statistics" - Get statistics for a band
+2. "pixel_value" - Get value at coordinates
+3. "describe" - Describe the raster dataset
+4. "metadata" - Show raster metadata
+
+Return JSON in this format:
+{{
+  "operation": "operation_name",
+  "band": band_number (optional, default 1),
+  "x": x_coordinate (for pixel_value),
+  "y": y_coordinate (for pixel_value)
+}}
+
+CRITICAL RULES:
+- Output ONLY valid JSON, nothing else
+- No explanations, no markdown, no code blocks
+- If unsure, use "describe" operation
+- Band numbers start at 1
+- Coordinates should be in the dataset's projection system
+
+User question: {question}
+
+JSON response:"""
+
+        try:
+            response = litellm.completion(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=float(os.getenv("MODEL_TEMPERATURE", "0.1")),
+                max_tokens=500,
+            )
+        except Exception as e:
+            cleaned_message = self._clean_litellm_error(str(e))
+            raise ValueError(cleaned_message) from None
+
+        content = response.choices[0].message.content
+        if content is None:
+            raise ValueError(f"No content returned from {self.model}")
+
+        return self._parse_json_response(content)
+
+    def _parse_json_response(self, content: str) -> dict:
+        """Parse and clean JSON response from LLM."""
+        # Remove markdown code blocks if present
+        content = content.strip()
+        if content.startswith("```json"):
+            content = content[7:]
+        elif content.startswith("```"):
+            content = content[3:]
+        if content.endswith("```"):
+            content = content[:-3]
+        content = content.strip()
+
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON response from LLM: {e}") from None
+
+    def _clean_litellm_error(self, error_message: str) -> str:
+        """Clean up litellm error message for user-friendly display."""
+        cleaned = error_message
+
+        # Remove common technical prefixes
+        prefixes_to_remove = [
+            r"litellm\.\w+Error:\s*",
+            r"\w+Error:\s*",
+            r"\w+Exception\s*-\s*",
+        ]
+
+        for prefix in prefixes_to_remove:
+            cleaned = re.sub(prefix, "", cleaned, flags=re.IGNORECASE)
+
+        cleaned = cleaned.strip()
+
+        if not cleaned:
+            cleaned = error_message
+
+        return cleaned

--- a/geodatatalk/geoprinter.py
+++ b/geodatatalk/geoprinter.py
@@ -1,0 +1,330 @@
+"""Console output wrapper for geospatial data visualization."""
+
+import json
+from typing import Any, Dict
+
+from rich import box
+from rich.console import Console
+from rich.table import Table
+from rich.panel import Panel
+from rich.tree import Tree
+
+
+class GeoPrinter:
+    """Console output wrapper with quiet mode support for geospatial data."""
+
+    def __init__(self, console: Console, quiet: bool = False):
+        self.console = console
+        self.quiet = quiet
+
+    def decorative(self, *args, **kwargs) -> None:
+        """Decorative output (banner, stats, progress) - suppressed in quiet mode."""
+        if not self.quiet:
+            self.console.print(*args, **kwargs)
+
+    def result(self, *args, **kwargs) -> None:
+        """Results output - always shown."""
+        self.console.print(*args, **kwargs)
+
+
+def print_logo(printer: GeoPrinter) -> None:
+    """Print the GeoDataTalk ASCII logo."""
+    logo = """
+[bold cyan]
+ ██████╗ ███████╗ ██████╗ ██████╗  █████╗ ████████╗ █████╗ ████████╗ █████╗ ██╗     ██╗  ██╗
+██╔════╝ ██╔════╝██╔═══██╗██╔══██╗██╔══██╗╚══██╔══╝██╔══██╗╚══██╔══╝██╔══██╗██║     ██║ ██╔╝
+██║  ███╗█████╗  ██║   ██║██║  ██║███████║   ██║   ███████║   ██║   ███████║██║     █████╔╝
+██║   ██║██╔══╝  ██║   ██║██║  ██║██╔══██║   ██║   ██╔══██║   ██║   ██╔══██║██║     ██╔═██╗
+╚██████╔╝███████╗╚██████╔╝██████╔╝██║  ██║   ██║   ██║  ██║   ██║   ██║  ██║███████╗██║  ██╗
+ ╚═════╝ ╚══════╝ ╚═════╝ ╚═════╝ ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝   ╚═╝   ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝
+[/bold cyan]
+[dim]Ask questions about your geospatial data (vector & raster) in natural language.[/dim]
+"""
+    printer.decorative(logo, highlight=False)
+
+
+def print_configuration_help(printer: GeoPrinter) -> None:
+    """Print helpful configuration message when LLM_MODEL is not set."""
+    printer.result("[yellow]⚠️  Please configure your LLM model first[/yellow]\n", highlight=False)
+    printer.result("[bold]Quick setup:[/bold]", highlight=False)
+    printer.result("  [cyan]export LLM_MODEL=gpt-4o[/cyan]", highlight=False)
+    printer.result("  [cyan]export OPENAI_API_KEY=your-key[/cyan]\n", highlight=False)
+    printer.result("[bold]Popular models:[/bold]", highlight=False)
+    printer.result("  [green]•[/green] gpt-4o, gpt-4o-mini, gpt-3.5-turbo [dim](OpenAI)[/dim]", highlight=False)
+    printer.result("  [green]•[/green] azure/gpt-4o [dim](Azure OpenAI)[/dim]", highlight=False)
+    printer.result("  [green]•[/green] claude-3-5-sonnet-20241022 [dim](Anthropic)[/dim]", highlight=False)
+    printer.result("  [green]•[/green] gemini-1.5-flash, gemini-1.5-pro [dim](Google)[/dim]", highlight=False)
+    printer.result("  [green]•[/green] ollama/llama3.1, ollama/mistral [dim](Ollama - local)[/dim]\n", highlight=False)
+
+
+def print_file_required_help(printer: GeoPrinter) -> None:
+    """Print helpful message when no data file is specified."""
+    printer.result("\n[yellow]📄 Please specify a geospatial data file to analyze[/yellow]\n", highlight=False)
+    printer.result("[bold]Usage:[/bold]", highlight=False)
+    printer.result("  [cyan]gdtalk[/cyan] [green]<file>[/green] [dim][question][/dim]\n", highlight=False)
+    printer.result("[bold]Examples:[/bold]", highlight=False)
+    printer.result("  [cyan]gdtalk[/cyan] [green]roads.shp[/green]", highlight=False)
+    printer.result("  [cyan]gdtalk[/cyan] [green]buildings.geojson[/green] [dim]-p 'How many buildings?'[/dim]", highlight=False)
+    printer.result("  [cyan]gdtalk[/cyan] [green]elevation.tif[/green] [dim]-p 'What is the max elevation?'[/dim]\n", highlight=False)
+    printer.result("[bold]Supported formats:[/bold] Shapefile, GeoJSON, GeoPackage, KML, GeoTIFF, and more via GDAL/OGR", highlight=False)
+    printer.result()
+
+
+def print_dataset_info(data_info: Dict[str, Any], printer: GeoPrinter, show_details: bool = True) -> None:
+    """Print geospatial dataset information."""
+    data_type = data_info.get('data_type', 'Unknown')
+
+    printer.decorative("\n[bold green]Dataset Information[/bold green]", highlight=False)
+    printer.decorative(f"• Type: [cyan]{data_type.upper()}[/cyan]", highlight=False)
+
+    if data_type == 'vector':
+        _print_vector_info(data_info, printer, show_details)
+    elif data_type == 'raster':
+        _print_raster_info(data_info, printer, show_details)
+
+    printer.decorative()
+
+
+def _print_vector_info(data_info: Dict[str, Any], printer: GeoPrinter, show_details: bool) -> None:
+    """Print vector dataset information."""
+    printer.decorative(f"• Geometry: [cyan]{data_info.get('geometry_type', 'Unknown')}[/cyan]", highlight=False)
+    printer.decorative(f"• Features: [cyan]{data_info.get('feature_count', 0):,}[/cyan]", highlight=False)
+    printer.decorative(f"• Projection: [cyan]{data_info.get('projection', 'Unknown')}[/cyan]", highlight=False)
+
+    if data_info.get('epsg'):
+        printer.decorative(f"• EPSG: [cyan]{data_info['epsg']}[/cyan]", highlight=False)
+
+    extent = data_info.get('extent', {})
+    if extent:
+        printer.decorative(
+            f"• Extent: [cyan]({extent.get('min_x', 0):.2f}, {extent.get('min_y', 0):.2f}) to "
+            f"({extent.get('max_x', 0):.2f}, {extent.get('max_y', 0):.2f})[/cyan]",
+            highlight=False
+        )
+
+    # Show fields table
+    if show_details and data_info.get('fields'):
+        table = Table(
+            show_header=True,
+            header_style="bold magenta",
+            box=box.SIMPLE,
+        )
+        table.add_column("Field", style="cyan")
+        table.add_column("Type", style="yellow")
+        table.add_column("Sample Values", style="dim")
+
+        for field in data_info['fields']:
+            samples = field.get('samples', [])
+            sample_str = ', '.join([str(s)[:20] for s in samples[:3]])
+            if not sample_str:
+                sample_str = '[no data]'
+            table.add_row(field['name'], field['type'], sample_str)
+
+        printer.decorative(table)
+
+
+def _print_raster_info(data_info: Dict[str, Any], printer: GeoPrinter, show_details: bool) -> None:
+    """Print raster dataset information."""
+    printer.decorative(
+        f"• Dimensions: [cyan]{data_info.get('width', 0):,} x {data_info.get('height', 0):,}[/cyan] pixels",
+        highlight=False
+    )
+    printer.decorative(f"• Bands: [cyan]{data_info.get('band_count', 0)}[/cyan]", highlight=False)
+    printer.decorative(f"• Projection: [cyan]{data_info.get('projection', 'Unknown')}[/cyan]", highlight=False)
+
+    if data_info.get('epsg'):
+        printer.decorative(f"• EPSG: [cyan]{data_info['epsg']}[/cyan]", highlight=False)
+
+    pixel_size = data_info.get('pixel_size', {})
+    if pixel_size:
+        printer.decorative(
+            f"• Pixel Size: [cyan]{pixel_size.get('x', 0):.6f} x {pixel_size.get('y', 0):.6f}[/cyan]",
+            highlight=False
+        )
+
+    extent = data_info.get('extent', {})
+    if extent:
+        printer.decorative(
+            f"• Extent: [cyan]({extent.get('min_x', 0):.2f}, {extent.get('min_y', 0):.2f}) to "
+            f"({extent.get('max_x', 0):.2f}, {extent.get('max_y', 0):.2f})[/cyan]",
+            highlight=False
+        )
+
+    # Show bands table
+    if show_details and data_info.get('bands'):
+        table = Table(
+            show_header=True,
+            header_style="bold magenta",
+            box=box.SIMPLE,
+        )
+        table.add_column("Band", style="cyan")
+        table.add_column("Type", style="yellow")
+        table.add_column("Interpretation", style="green")
+        table.add_column("Min", style="dim")
+        table.add_column("Max", style="dim")
+
+        for band in data_info['bands']:
+            table.add_row(
+                str(band.get('number', '')),
+                band.get('data_type', 'Unknown'),
+                band.get('color_interpretation', 'Unknown'),
+                f"{band.get('min', 'N/A'):.2f}" if isinstance(band.get('min'), (int, float)) else 'N/A',
+                f"{band.get('max', 'N/A'):.2f}" if isinstance(band.get('max'), (int, float)) else 'N/A'
+            )
+
+        printer.decorative(table)
+
+
+def print_query_results(result: Dict[str, Any], printer: GeoPrinter) -> None:
+    """Print query results based on result type."""
+    result_type = result.get('type', 'unknown')
+
+    if result_type == 'description':
+        data_info = result.get('data', {})
+        print_dataset_info(data_info, printer, show_details=True)
+
+    elif result_type == 'metadata':
+        data_info = result.get('data', {})
+        print_dataset_info(data_info, printer, show_details=True)
+
+    elif result_type == 'features':
+        _print_features(result, printer)
+
+    elif result_type == 'count':
+        count = result.get('count', 0)
+        total = result.get('total', 0)
+        printer.result(f"\n[bold green]Feature Count:[/bold green] [cyan]{count:,}[/cyan]", highlight=False)
+        if total != count:
+            printer.result(f"[dim](Total features in dataset: {total:,})[/dim]", highlight=False)
+
+    elif result_type == 'statistics':
+        _print_statistics(result, printer)
+
+    elif result_type == 'band_statistics':
+        _print_band_statistics(result, printer)
+
+    elif result_type == 'pixel_value':
+        _print_pixel_value(result, printer)
+
+    else:
+        printer.result(f"\n[yellow]Unknown result type: {result_type}[/yellow]", highlight=False)
+
+
+def _print_features(result: Dict[str, Any], printer: GeoPrinter, limit: int = 20) -> None:
+    """Print feature results as a table."""
+    features = result.get('features', [])
+    count = result.get('count', len(features))
+
+    if not features:
+        printer.result("[yellow]No features found.[/yellow]", highlight=False)
+        return
+
+    # Build table from features
+    table = Table(
+        show_header=True,
+        header_style="bold magenta",
+        box=box.SIMPLE,
+        title=f"[bold]Features (showing {min(len(features), limit)} of {count})[/bold]"
+    )
+
+    # Get columns from first feature (excluding geometry)
+    first_feature = features[0]
+    columns = [k for k in first_feature.keys() if k not in ['geometry', 'geometry_type']]
+
+    for col in columns:
+        table.add_column(col)
+
+    # Add rows
+    for i, feature in enumerate(features[:limit]):
+        row_data = []
+        for col in columns:
+            value = feature.get(col, '')
+            value_str = str(value)
+            if len(value_str) > 50:
+                value_str = value_str[:50] + '...'
+            row_data.append(value_str)
+        table.add_row(*row_data)
+
+    printer.result(table)
+
+    if len(features) > limit:
+        printer.result(f"[dim]Showing first {limit} of {len(features)} features[/dim]", highlight=False)
+
+
+def _print_statistics(result: Dict[str, Any], printer: GeoPrinter) -> None:
+    """Print field statistics."""
+    data = result.get('data', {})
+
+    if 'error' in data:
+        printer.result(f"\n[yellow]{data['error']}[/yellow]", highlight=False)
+        return
+
+    field = data.get('field', 'Unknown')
+
+    table = Table(
+        show_header=False,
+        box=box.SIMPLE,
+        title=f"[bold]Statistics for field: {field}[/bold]"
+    )
+    table.add_column("Statistic", style="cyan")
+    table.add_column("Value", style="yellow")
+
+    table.add_row("Count", f"{data.get('count', 0):,}")
+    table.add_row("Min", f"{data.get('min', 0):.2f}")
+    table.add_row("Max", f"{data.get('max', 0):.2f}")
+    table.add_row("Mean", f"{data.get('mean', 0):.2f}")
+    table.add_row("Median", f"{data.get('median', 0):.2f}")
+
+    printer.result(table)
+
+
+def _print_band_statistics(result: Dict[str, Any], printer: GeoPrinter) -> None:
+    """Print raster band statistics."""
+    band = result.get('band', 1)
+    data = result.get('data', {})
+
+    table = Table(
+        show_header=False,
+        box=box.SIMPLE,
+        title=f"[bold]Band {band} Statistics[/bold]"
+    )
+    table.add_column("Statistic", style="cyan")
+    table.add_column("Value", style="yellow")
+
+    table.add_row("Min", f"{data.get('min', 0):.4f}")
+    table.add_row("Max", f"{data.get('max', 0):.4f}")
+    table.add_row("Mean", f"{data.get('mean', 0):.4f}")
+    table.add_row("Std Dev", f"{data.get('stddev', 0):.4f}")
+
+    printer.result(table)
+
+
+def _print_pixel_value(result: Dict[str, Any], printer: GeoPrinter) -> None:
+    """Print pixel value result."""
+    x = result.get('x', 0)
+    y = result.get('y', 0)
+    band = result.get('band', 1)
+    value = result.get('value')
+
+    if value is None:
+        printer.result(
+            f"\n[yellow]No pixel value at coordinates ({x}, {y}) - outside raster extent[/yellow]",
+            highlight=False
+        )
+    else:
+        printer.result(
+            f"\n[bold green]Pixel Value:[/bold green] [cyan]{value:.4f}[/cyan]",
+            highlight=False
+        )
+        printer.result(f"[dim]Band {band} at coordinates ({x}, {y})[/dim]", highlight=False)
+
+
+def output_json(result: Dict[str, Any], operation: Dict[str, Any]) -> None:
+    """Output query results as JSON."""
+    output = {
+        "operation": operation,
+        "result": result,
+        "error": None,
+    }
+    # Convert any non-serializable objects
+    print(json.dumps(output, indent=2, default=str))

--- a/geodatatalk/geoquery.py
+++ b/geodatatalk/geoquery.py
@@ -1,0 +1,202 @@
+"""Core geospatial query processing logic."""
+
+from typing import Any, Dict, List, Optional
+
+from geodatatalk.geodatabase import GeoDataSource
+from geodatatalk.geollm import GeoLLMProvider
+from geodatatalk.geoprinter import GeoPrinter
+
+
+def process_query(
+    provider: GeoLLMProvider,
+    question: str,
+    geo_source: GeoDataSource,
+    data_info: dict,
+    printer: GeoPrinter,
+) -> Dict[str, Any]:
+    """Process a natural language query about geospatial data."""
+    try:
+        printer.decorative("[dim]Analyzing your question...[/dim]")
+        operation = provider.to_geo_operation(question, data_info)
+
+        printer.decorative("[dim]Executing geospatial operation...[/dim]")
+
+        if data_info['data_type'] == 'vector':
+            result = _execute_vector_operation(geo_source, operation, data_info)
+        else:
+            result = _execute_raster_operation(geo_source, operation, data_info)
+
+        return {
+            "operation": operation,
+            "result": result,
+            "error": None,
+        }
+    except Exception as e:
+        return {
+            "operation": None,
+            "result": None,
+            "error": str(e),
+        }
+
+
+def _execute_vector_operation(
+    geo_source: GeoDataSource,
+    operation: dict,
+    data_info: dict
+) -> Dict[str, Any]:
+    """Execute vector data operation."""
+    op_type = operation.get('operation', 'describe')
+
+    if op_type == 'describe':
+        return {
+            'type': 'description',
+            'data': data_info
+        }
+
+    elif op_type == 'list_features':
+        limit = operation.get('limit', 10)
+        sql = operation.get('sql')
+        bbox = operation.get('bbox')
+
+        features = geo_source.query_features(sql=sql, bbox=bbox, limit=limit)
+
+        return {
+            'type': 'features',
+            'count': len(features),
+            'features': features,
+            'total': data_info.get('feature_count', 0)
+        }
+
+    elif op_type == 'count_features':
+        sql = operation.get('sql')
+        bbox = operation.get('bbox')
+
+        features = geo_source.query_features(sql=sql, bbox=bbox)
+
+        return {
+            'type': 'count',
+            'count': len(features),
+            'total': data_info.get('feature_count', 0)
+        }
+
+    elif op_type == 'filter_features':
+        sql = operation.get('sql')
+        limit = operation.get('limit', 10)
+        bbox = operation.get('bbox')
+
+        features = geo_source.query_features(sql=sql, bbox=bbox, limit=limit)
+
+        return {
+            'type': 'features',
+            'count': len(features),
+            'features': features,
+            'filter': sql or 'spatial filter'
+        }
+
+    elif op_type == 'spatial_filter':
+        bbox = operation.get('bbox')
+        if not bbox:
+            raise ValueError("Bounding box required for spatial filter")
+
+        limit = operation.get('limit', 10)
+        features = geo_source.query_features(bbox=bbox, limit=limit)
+
+        return {
+            'type': 'features',
+            'count': len(features),
+            'features': features,
+            'bbox': bbox
+        }
+
+    elif op_type == 'statistics':
+        field = operation.get('field')
+        if not field:
+            raise ValueError("Field name required for statistics")
+
+        sql = operation.get('sql')
+        features = geo_source.query_features(sql=sql)
+
+        # Calculate basic statistics
+        values = []
+        for feature in features:
+            value = feature.get(field)
+            if value is not None and isinstance(value, (int, float)):
+                values.append(value)
+
+        if not values:
+            return {
+                'type': 'statistics',
+                'field': field,
+                'error': 'No numeric values found'
+            }
+
+        values.sort()
+        n = len(values)
+        stats = {
+            'field': field,
+            'count': n,
+            'min': min(values),
+            'max': max(values),
+            'mean': sum(values) / n,
+            'median': values[n // 2] if n % 2 else (values[n // 2 - 1] + values[n // 2]) / 2
+        }
+
+        return {
+            'type': 'statistics',
+            'data': stats
+        }
+
+    else:
+        raise ValueError(f"Unknown vector operation: {op_type}")
+
+
+def _execute_raster_operation(
+    geo_source: GeoDataSource,
+    operation: dict,
+    data_info: dict
+) -> Dict[str, Any]:
+    """Execute raster data operation."""
+    op_type = operation.get('operation', 'describe')
+
+    if op_type == 'describe':
+        return {
+            'type': 'description',
+            'data': data_info
+        }
+
+    elif op_type == 'metadata':
+        return {
+            'type': 'metadata',
+            'data': data_info
+        }
+
+    elif op_type == 'band_statistics':
+        band = operation.get('band', 1)
+        stats = geo_source.get_band_statistics(band)
+
+        return {
+            'type': 'band_statistics',
+            'band': band,
+            'data': stats
+        }
+
+    elif op_type == 'pixel_value':
+        x = operation.get('x')
+        y = operation.get('y')
+        band = operation.get('band', 1)
+
+        if x is None or y is None:
+            raise ValueError("X and Y coordinates required for pixel value query")
+
+        value = geo_source.get_pixel_value(x, y, band)
+
+        return {
+            'type': 'pixel_value',
+            'x': x,
+            'y': y,
+            'band': band,
+            'value': value
+        }
+
+    else:
+        raise ValueError(f"Unknown raster operation: {op_type}")

--- a/geodatatalk/main.py
+++ b/geodatatalk/main.py
@@ -1,0 +1,223 @@
+"""GeoDataTalk CLI - Natural language interface for geospatial data files."""
+
+import os
+import sys
+import argparse
+from importlib.metadata import version, PackageNotFoundError
+
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.prompt import Prompt
+
+from geodatatalk.geodatabase import GeoDataSource
+from geodatatalk import geoquery
+from geodatatalk.geollm import GeoLLMProvider
+from geodatatalk.geoprinter import (
+    GeoPrinter,
+    print_logo,
+    print_configuration_help,
+    print_file_required_help,
+    print_dataset_info,
+    print_query_results,
+    output_json,
+)
+
+
+class CleanArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser with clean error messages (no program name prefix)."""
+
+    def error(self, message):
+        """Print error message without program name prefix."""
+        self.print_usage(sys.stderr)
+        self.exit(2, f"error: {message}\n")
+
+
+def main():
+    """Main CLI entry point."""
+    console = Console()
+
+    try:
+        epilog_text = """
+examples:
+  # Interactive mode
+  gdtalk roads.shp
+  gdtalk elevation.tif
+
+  # Single query with different outputs
+  gdtalk buildings.geojson -p 'How many buildings?'
+  gdtalk roads.shp -p 'Show roads longer than 1km'
+  gdtalk elevation.tif -p 'What is the elevation range?' --json
+
+  # Other options
+  gdtalk data.gpkg --no-schema                         # Hide schema table
+  gdtalk parcels.shp -p 'Count parcels' --operation    # Show operation details
+"""
+        parser = CleanArgumentParser(
+            prog="gdtalk",
+            description="",
+            epilog=epilog_text,
+            add_help=True,
+            formatter_class=argparse.RawDescriptionHelpFormatter
+        )
+        parser.add_argument("file", nargs="?", help="Geospatial file to analyze (vector or raster)")
+
+        # Query mode
+        parser.add_argument(
+            "-p", "--prompt", help="Run a single query in non-interactive mode"
+        )
+
+        # Output formats (only with -p)
+        format_group = parser.add_mutually_exclusive_group()
+        format_group.add_argument(
+            "--json",
+            action="store_true",
+            help="Output results as JSON (requires -p, for scripting)",
+        )
+
+        # Display options
+        parser.add_argument(
+            "--operation",
+            action="store_true",
+            help="Show generated operation details"
+        )
+        parser.add_argument(
+            "--no-schema",
+            action="store_true",
+            help="Don't show field/band details table when loading data",
+        )
+
+        args = parser.parse_args()
+
+        # Validate format options require -p
+        if args.json and not args.prompt:
+            parser.error("--json requires -p/--prompt (non-interactive mode)")
+
+        # Create printer (quiet in non-interactive mode)
+        printer = GeoPrinter(console, quiet=args.prompt is not None)
+
+        print_logo(printer)
+
+        # Load .env file if it exists (but don't require it)
+        load_dotenv()
+
+        # Get LLM model from environment
+        model = os.getenv("LLM_MODEL")
+        if not model:
+            print_configuration_help(printer)
+            sys.exit(1)
+
+        # Check if file is provided
+        if not args.file:
+            print_file_required_help(printer)
+            sys.exit(1)
+
+        # Create LLM provider
+        provider = GeoLLMProvider(model)
+
+        # Display version and model info
+        try:
+            app_version = version("geodatatalk-cli")
+        except PackageNotFoundError:
+            app_version = "0.1.0"
+
+        version_text = f"GeoDataTalk v{app_version} — powered by {model} & GDAL"
+        printer.decorative(version_text, highlight=False)
+
+        # Load geospatial data
+        path = args.file
+        printer.decorative(f"\n[dim]Loading geospatial data from {path}...[/dim]", highlight=False)
+
+        try:
+            geo_source = GeoDataSource(path)
+        except Exception as e:
+            printer.result(f"\n[red]Error loading file:[/red] {e}", highlight=False)
+            sys.exit(1)
+
+        data_info = geo_source.get_info()
+
+        printer.decorative("\n[green]Data loaded successfully![/green]", highlight=False)
+
+        # Display dataset information
+        print_dataset_info(data_info, printer, not args.no_schema)
+
+        # Non-interactive mode
+        if args.prompt:
+            result = geoquery.process_query(
+                provider,
+                args.prompt,
+                geo_source,
+                data_info,
+                printer,
+            )
+
+            if result["error"]:
+                if args.json:
+                    output_json(result["result"], result["operation"])
+                else:
+                    printer.result(f"\n[red]Error:[/red] {result['error']}\n", highlight=False)
+                geo_source.close()
+                sys.exit(1)
+
+            # Machine-readable output (JSON)
+            if args.json:
+                output_json(result["result"], result["operation"])
+            # Human-readable output (non-interactive mode)
+            else:
+                # Show operation if requested
+                if args.operation:
+                    printer.result(f"\n[cyan]Operation:[/cyan] {result['operation']}", highlight=False)
+
+                # Show results
+                print_query_results(result["result"], printer)
+
+            geo_source.close()
+            return
+
+        # Interactive mode
+        printer.result(
+            "Ask questions about your geospatial data. "
+            "Type 'quit', 'exit', 'stop', or press Ctrl+C to exit.\n",
+            highlight=False
+        )
+
+        while True:
+            try:
+                q = Prompt.ask("[bold blue]Question[/bold blue]")
+            except EOFError:
+                printer.result("\n[dim]Goodbye![/dim]\n", highlight=False)
+                break
+
+            if q.lower() in ["quit", "exit", "q", "stop", "bye", "goodbye"]:
+                printer.result("[dim]Goodbye![/dim]\n", highlight=False)
+                break
+            if not q.strip():
+                continue
+
+            result = geoquery.process_query(
+                provider,
+                q,
+                geo_source,
+                data_info,
+                printer,
+            )
+
+            if result["error"]:
+                printer.result(f"\n[red]Error:[/red] {result['error']}\n", highlight=False)
+            else:
+                if args.operation:
+                    printer.result(f"\n[cyan]Operation:[/cyan] {result['operation']}", highlight=False)
+
+                print_query_results(result["result"], printer)
+
+        geo_source.close()
+
+    except KeyboardInterrupt:
+        console.print("\n[dim]Goodbye![/dim]\n", highlight=False)
+        sys.exit(0)
+    except Exception as e:
+        console.print(f"\n[red]Error:[/red] {e}", highlight=False)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Create a new CLI tool geodatatalk-cli based on datatalk-cli architecture but adapted for geospatial data using GDAL/OGR. This tool allows users to query both vector and raster geospatial data using natural language.

Key features:
- Support for 80+ vector formats (Shapefile, GeoJSON, GeoPackage, KML, etc.)
- Support for 140+ raster formats (GeoTIFF, NetCDF, HDF, etc.)
- Natural language queries using LLM (OpenAI, Anthropic, Ollama, etc.)
- Interactive and non-interactive modes
- JSON output for scripting
- Privacy-focused: only schema/metadata sent to LLM

Architecture:
- geodatabase.py: GDAL/OGR operations for vector and raster data
- geollm.py: LLM provider for converting natural language to geo operations
- geoquery.py: Query processing and execution logic
- geoprinter.py: Rich console output for geospatial results
- main.py: CLI entry point with argparse

Installation command will be: pip install geodatatalk-cli
Usage command: gdtalk <file> [-p "question"]